### PR TITLE
focus and destroy 

### DIFF
--- a/lib/mjml-preview.js
+++ b/lib/mjml-preview.js
@@ -58,7 +58,10 @@ export default {
       previewPane.destroyItem(previewPane.itemForURI(uri))
     }
 
+    const previousActivePane = atom.workspace.getActivePane()
+
     atom.workspace.open(uri, { split: 'right', searchAllPanes: true }).then(() => MJMLPaneView.render(currentEditor))
+      .done(() => previousActivePane.activate())
   },
 
   mjmlPreviewOpener(uri) {

--- a/lib/mjml-preview.js
+++ b/lib/mjml-preview.js
@@ -47,15 +47,10 @@ export default {
     }
 
     const uri = 'mjml-preview://file'
-    const previewPane = atom.workspace.paneForURI(uri)
     const fileGrammar = currentEditor.getGrammar()
 
     if (fileGrammar.scopeName !== 'text.mjml.basic') {
       return;
-    }
-
-    if (previewPane) {
-      previewPane.destroyItem(previewPane.itemForURI(uri))
     }
 
     const previousActivePane = atom.workspace.getActivePane()


### PR DESCRIPTION
Hello. Made a few changes:
* Added return focus to the active tab after creating a preview pane.
* Removed the destruction of the preview panel every time you save.

