### PR TITLE
fix onSave when more than 1 pane already opened

### DIFF
--- a/lib/mjml-preview.js
+++ b/lib/mjml-preview.js
@@ -22,7 +22,7 @@ export default {
   activate() {
     this.subscriptions = new CompositeDisposable()
     this.subscriptions.add(atom.workspace.observeTextEditors((editor) => {
-      this.subscriptions.add(editor.onDidSave(() => {
+      this.subscriptions.add(editor.getBuffer().onDidSave(() => {
         if (atom.config.get('mjml-preview.triggerOnSave')) {
           this.openPane(editor)
         }
@@ -39,24 +39,28 @@ export default {
   },
 
   openPane(editor) {
-    const currentEditor = editor || atom.workspace.getActiveTextEditor()
+    const activeEditor = atom.workspace.getActiveTextEditor()
+    const currentEditor = editor || activeEditor
 
     if (!currentEditor) {
       // probably trying to render an mjml-preview pane
       return;
     }
 
-    const uri = 'mjml-preview://file'
-    const fileGrammar = currentEditor.getGrammar()
+    if (currentEditor.id === atom.workspace.getActiveTextEditor().id) {
+      const uri = 'mjml-preview://file'
+      const fileGrammar = currentEditor.getGrammar()
 
-    if (fileGrammar.scopeName !== 'text.mjml.basic') {
-      return;
+      if (fileGrammar.scopeName !== 'text.mjml.basic') {
+        return;
+      }
+
+      const previousActivePane = atom.workspace.getActivePane()
+
+      atom.workspace.open(uri, { split: 'right', searchAllPanes: true })
+        .then(() => MJMLPaneView.render(currentEditor))
+        .done(() => previousActivePane.activate())
     }
-
-    const previousActivePane = atom.workspace.getActivePane()
-
-    atom.workspace.open(uri, { split: 'right', searchAllPanes: true }).then(() => MJMLPaneView.render(currentEditor))
-      .done(() => previousActivePane.activate())
   },
 
   mjmlPreviewOpener(uri) {


### PR DESCRIPTION
Atom seems to trigger 'onDidSave' event once for each already opened panes (and even for panes that have been closed). It resulted in the opening of multiple preview panes.
It may be the origin of #15 too.

This makes openPane execute only for active pane.
