### PR TITLE
Fixed deprecation warning

### DIFF
--- a/lib/mjml-preview.js
+++ b/lib/mjml-preview.js
@@ -62,7 +62,7 @@ export default {
             return view.render(currentEditor)
           }
         })
-        .done(() => previousActivePane.activate())
+        .then(() => previousActivePane.activate())
     }
   },
 


### PR DESCRIPTION
the plugin currently gives a deprecation warning, this fix simply changes `.done()` into `.then()` in order to fix this